### PR TITLE
Fix a bug where the script wouldn't properly number lines containing digits ; Add missing "." after line number

### DIFF
--- a/plugin/numbered.vim
+++ b/plugin/numbered.vim
@@ -20,7 +20,7 @@ function! s:Numbered(...) range
         if strlen(match)
             let line = substitute(line, match, n, '')
         else
-            let line = n.' '.line
+            let line = n.'. '.line
         endif
         call setline(lnum, substitute(line, '\s\+$', '', ''))
         let n += 1

--- a/plugin/numbered.vim
+++ b/plugin/numbered.vim
@@ -16,7 +16,7 @@ function! s:Numbered(...) range
     let n = a:0 == 0 ? 1 : a:1
     for lnum in range(a:firstline, a:lastline)
         let line = getline(lnum)
-        let match = matchstr(line, '\d\+')
+        let match = matchstr(line, '^\d\+')
         if strlen(match)
             let line = substitute(line, match, n, '')
         else


### PR DESCRIPTION
Hello,

Thank you for this useful script! Here are some minor, yet useful, improvements.

## Fix: prevent failure when a line contains a digit
Given the following list:
```
foo 10
bar
baz 3
qux
```
Current behavior:
```
foo 10
2 bar
baz 3
4 qux
```
Fixed behavior:
```
1 foo 10
2 bar
3 baz 3
4 qux
```

## Enh: add missing "." after line number
Given the following list:
```
foo
bar
baz
qux
```
Current behavior:
```
1 foo
2 bar
3 baz
4 qux
```
Fixed behavior:
```
1. foo
2. bar
3. baz
4. qux
```